### PR TITLE
fix: Promotion 도메인 서비스의 상품 API 스펙에 맞추어 변경

### DIFF
--- a/cart_service/src/main/java/on/ssgdeal/cart_service/application/service/CartServiceImpl.java
+++ b/cart_service/src/main/java/on/ssgdeal/cart_service/application/service/CartServiceImpl.java
@@ -88,13 +88,13 @@ public class CartServiceImpl implements CartService {
         List<CartProduct> cartProducts = cartRepository.findAll(key);
         log.info("getCarts cartProducts: {}", cartProducts);
 
-        List<GetProductDetailsResponse> detailsResponseList =
+        GetProductDetailsResponse detailsResponse =
             productService.getProductsByHashKeys(cartProducts);
         List<GetProductOptionsResponseDto> productOptionsResponses =
             productService.getProductOptions(cartProducts);
 
         return GetProductsByIdsResponseDto.from(
-            detailsResponseList, productOptionsResponses, cartProducts);
+            detailsResponse, productOptionsResponses, cartProducts);
     }
 
     @Override

--- a/cart_service/src/main/java/on/ssgdeal/cart_service/application/service/ProductService.java
+++ b/cart_service/src/main/java/on/ssgdeal/cart_service/application/service/ProductService.java
@@ -8,7 +8,7 @@ import on.ssgdeal.cart_service.infrastructure.client.product.feign.dto.GetProduc
 
 public interface ProductService {
 
-    List<GetProductDetailsResponse> getProductsByHashKeys(List<CartProduct> cartProducts);
+    GetProductDetailsResponse getProductsByHashKeys(List<CartProduct> cartProducts);
 
     List<GetProductOptionsResponseDto> getProductOptions(List<CartProduct> cartProducts);
 

--- a/cart_service/src/main/java/on/ssgdeal/cart_service/application/service/dto/GetProductsByIdsResponseDto.java
+++ b/cart_service/src/main/java/on/ssgdeal/cart_service/application/service/dto/GetProductsByIdsResponseDto.java
@@ -3,12 +3,13 @@ package on.ssgdeal.cart_service.application.service.dto;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import on.ssgdeal.cart_service.application.generator.RedisKeyGenerator;
 import on.ssgdeal.cart_service.application.service.dto.GetProductsByIdsResponseDto.SubCart.Product;
 import on.ssgdeal.cart_service.application.service.dto.GetProductsByIdsResponseDto.SubCart.Product.Option;
 import on.ssgdeal.cart_service.domain.entity.CartProduct;
 import on.ssgdeal.cart_service.infrastructure.client.product.dto.GetProductOptionsResponseDto;
 import on.ssgdeal.cart_service.infrastructure.client.product.feign.dto.GetProductDetailsResponse;
-import on.ssgdeal.cart_service.application.generator.RedisKeyGenerator;
+import on.ssgdeal.cart_service.infrastructure.client.product.feign.dto.GetProductDetailsResponse.ProductDetail;
 
 public record GetProductsByIdsResponseDto(
     Long originalTotalPrice,
@@ -45,18 +46,19 @@ public record GetProductsByIdsResponseDto(
                 Long extraPrice
             ) {
 
-
             }
         }
     }
 
     public static GetProductsByIdsResponseDto from(
-        List<GetProductDetailsResponse> detailsResponseList,
+        GetProductDetailsResponse productDetailsResponse,
         List<GetProductOptionsResponseDto> productOptionsResponses,
         List<CartProduct> cartProducts
     ) {
-        Map<Long, List<GetProductDetailsResponse>> groupedByCompany = detailsResponseList.stream()
-            .collect(Collectors.groupingBy(GetProductDetailsResponse::companyId));
+        List<ProductDetail> productDetails = productDetailsResponse.productDetails();
+
+        Map<Long, List<ProductDetail>> groupedByCompany = productDetails.stream()
+            .collect(Collectors.groupingBy(ProductDetail::companyId));
 
         List<SubCart> subCarts = groupedByCompany.values().stream().map(
             getProductDetailsResponses -> {

--- a/cart_service/src/main/java/on/ssgdeal/cart_service/infrastructure/client/product/ProductServiceImpl.java
+++ b/cart_service/src/main/java/on/ssgdeal/cart_service/infrastructure/client/product/ProductServiceImpl.java
@@ -3,6 +3,7 @@ package on.ssgdeal.cart_service.infrastructure.client.product;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import on.ssgdeal.cart_service.application.generator.RedisKeyGenerator;
 import on.ssgdeal.cart_service.application.service.ProductService;
 import on.ssgdeal.cart_service.domain.entity.CartProduct;
 import on.ssgdeal.cart_service.exception.CartException.NotEnoughStockException;
@@ -13,7 +14,6 @@ import on.ssgdeal.cart_service.infrastructure.client.product.feign.dto.GetProduc
 import on.ssgdeal.cart_service.infrastructure.client.product.feign.dto.GetProductDetailsRequest.ProductDetail;
 import on.ssgdeal.cart_service.infrastructure.client.product.feign.dto.GetProductDetailsResponse;
 import on.ssgdeal.cart_service.infrastructure.client.product.feign.dto.GetProductOptionsResponse;
-import on.ssgdeal.cart_service.application.generator.RedisKeyGenerator;
 import on.ssgdeal.common.presentation.dto.CommonResponse;
 import org.springframework.stereotype.Service;
 
@@ -25,22 +25,20 @@ public class ProductServiceImpl implements ProductService {
     private final ProductFeignClient productFeignClient;
 
     @Override
-    public List<GetProductDetailsResponse> getProductsByHashKeys(List<CartProduct> cartProducts) {
+    public GetProductDetailsResponse getProductsByHashKeys(List<CartProduct> cartProducts) {
         log.info("getProductsByIds cartProducts: {}", cartProducts);
 
-        return cartProducts.stream()
-            .map(key -> {
-                GetProductDetailsRequest request = new GetProductDetailsRequest(
-                    List.of(
-                        new ProductDetail(
-                            RedisKeyGenerator.parseProductId(key.getHashKey()),
-                            RedisKeyGenerator.parseOptionId(key.getHashKey())
-                        )
-                    )
-                );
-                return productFeignClient.getProductDetails(request).data();
-            })
+        List<ProductDetail> productDetailList = cartProducts.stream()
+            .map(key ->
+                new ProductDetail(
+                    RedisKeyGenerator.parseProductId(key.getHashKey()),
+                    RedisKeyGenerator.parseOptionId(key.getHashKey())
+                )
+            )
             .toList();
+
+        GetProductDetailsRequest request = GetProductDetailsRequest.from(productDetailList);
+        return productFeignClient.getProductDetails(request).data();
     }
 
     @Override

--- a/cart_service/src/main/java/on/ssgdeal/cart_service/infrastructure/client/product/feign/ProductFeignClient.java
+++ b/cart_service/src/main/java/on/ssgdeal/cart_service/infrastructure/client/product/feign/ProductFeignClient.java
@@ -15,9 +15,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface ProductFeignClient {
 
     @PostMapping("/internal/v1/promotions/products/detail")
-    CommonResponse<GetProductDetailsResponse> getProductDetails(@RequestBody GetProductDetailsRequest request);
+    CommonResponse<GetProductDetailsResponse> getProductDetails(
+        @RequestBody GetProductDetailsRequest request);
 
-    @GetMapping("/api/v1/promotions/products/options/list")
+    @GetMapping("/api/v1/promotions/products/options")
     CommonResponse<GetProductOptionsResponse> getProductOptions(@RequestParam Long productId);
 
     @GetMapping("/internal/v1/promotions/products/{productId}/options/{optionId}/stock")

--- a/cart_service/src/main/java/on/ssgdeal/cart_service/infrastructure/client/product/feign/dto/GetProductDetailsRequest.java
+++ b/cart_service/src/main/java/on/ssgdeal/cart_service/infrastructure/client/product/feign/dto/GetProductDetailsRequest.java
@@ -3,7 +3,7 @@ package on.ssgdeal.cart_service.infrastructure.client.product.feign.dto;
 import java.util.List;
 
 public record GetProductDetailsRequest(
-    List<ProductDetail> getProductDetails
+    List<ProductDetail> productDetails
 ) {
 
     public record ProductDetail(
@@ -11,5 +11,13 @@ public record GetProductDetailsRequest(
         Long optionId
     ) {
 
+    }
+
+    public static GetProductDetailsRequest from(
+        List<ProductDetail> productDetailList
+    ) {
+        return new GetProductDetailsRequest(
+            productDetailList
+        );
     }
 }

--- a/cart_service/src/main/java/on/ssgdeal/cart_service/infrastructure/client/product/feign/dto/GetProductDetailsResponse.java
+++ b/cart_service/src/main/java/on/ssgdeal/cart_service/infrastructure/client/product/feign/dto/GetProductDetailsResponse.java
@@ -1,17 +1,37 @@
 package on.ssgdeal.cart_service.infrastructure.client.product.feign.dto;
 
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 public record GetProductDetailsResponse(
-    String promotionStatus,
-    Long companyId,
-    String companyName,
-    Long productId,
-    String productName,
-    String productPreviewImgUrl,
-    Long originalPrice,
-    Long promotionPrice,
-    Long optionId,
-    String optionName,
-    Long extraPrice
+    List<ProductDetail> productDetails
 ) {
+
+    public record ProductDetail(
+        PromotionStatus promotionStatus,
+        Long companyId,
+        String companyName,
+        Long productId,
+        String productName,
+        String productPreviewImgUrl,
+        Long originalPrice,
+        Long promotionPrice,
+        Long optionId,
+        String optionName,
+        Long extraPrice
+    ) {
+
+        @Getter
+        @AllArgsConstructor
+        public enum PromotionStatus {
+
+            PENDING("예정"),
+            IN_PROGRESS("진행 중"),
+            FINISHED("종료"),
+            ;
+            private final String description;
+        }
+    }
 
 }

--- a/cart_service/src/test/java/on/ssgdeal/cart_service/application/service/CartServiceImplTest.java
+++ b/cart_service/src/test/java/on/ssgdeal/cart_service/application/service/CartServiceImplTest.java
@@ -13,6 +13,8 @@ import on.ssgdeal.cart_service.domain.repository.CartRepository;
 import on.ssgdeal.cart_service.infrastructure.client.product.dto.GetProductOptionsResponseDto;
 import on.ssgdeal.cart_service.infrastructure.client.product.dto.IsProductStockAvailableRequestDto;
 import on.ssgdeal.cart_service.infrastructure.client.product.feign.dto.GetProductDetailsResponse;
+import on.ssgdeal.cart_service.infrastructure.client.product.feign.dto.GetProductDetailsResponse.ProductDetail;
+import on.ssgdeal.cart_service.infrastructure.client.product.feign.dto.GetProductDetailsResponse.ProductDetail.PromotionStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -51,12 +53,12 @@ class CartServiceImplTest {
             cartRepository,
             new ProductService() {
                 @Override
-                public List<GetProductDetailsResponse> getProductsByHashKeys(
+                public GetProductDetailsResponse getProductsByHashKeys(
                     List<CartProduct> cartProducts
                 ) {
-                    return List.of(
-                        new GetProductDetailsResponse(
-                            "ING",
+                    List<ProductDetail> productDetails = List.of(
+                        new ProductDetail(
+                            PromotionStatus.IN_PROGRESS,
                             1L,
                             "companyName_1",
                             1L,
@@ -68,8 +70,8 @@ class CartServiceImplTest {
                             "optionName_1",
                             0L
                         ),
-                        new GetProductDetailsResponse(
-                            "ING",
+                        new ProductDetail(
+                            PromotionStatus.IN_PROGRESS,
                             1L,
                             "companyName_1",
                             2L,
@@ -81,8 +83,8 @@ class CartServiceImplTest {
                             "optionName_1",
                             0L
                         ),
-                        new GetProductDetailsResponse(
-                            "ING",
+                        new ProductDetail(
+                            PromotionStatus.IN_PROGRESS,
                             2L,
                             "companyName_2",
                             3L,
@@ -95,6 +97,7 @@ class CartServiceImplTest {
                             500L
                         )
                     );
+                    return new GetProductDetailsResponse(productDetails);
                 }
                 @Override
                 public List<GetProductOptionsResponseDto> getProductOptions(


### PR DESCRIPTION
## ✨ 변경 타입
* [ ] 신규 기능 추가/수정
* [X] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 변경 내용
* **as-is**
  * 상품 API 스펙과 맞지 않아 통신 오류 발생

* **to-be**
  * 상품 API 스펙에 맞추어 변경

## 💡 추가 설명

## ⚡️ 관련 이슈

## 📚 참고 자료 (선택 사항)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 장바구니에서 여러 상품 정보를 개별적으로 조회하던 방식을 하나의 통합 요청으로 변경하여, 상품 정보가 보다 정확하게 표시됩니다.
- **리팩터**
  - 상품 상세 응답 구조가 개선되어, 프로모션 상태가 명확한 타입(enum)으로 제공됩니다.
- **테스트**
  - 변경된 상품 정보 응답 구조에 맞춰 테스트 코드가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->