### PR TITLE
fix: notification service - JpaAuditing 및 application 사용하도록 테스트 코드 수정

### DIFF
--- a/notification_service/src/main/java/on/ssgdeal/notification_service/presentation/internal/NotificationInternalController.java
+++ b/notification_service/src/main/java/on/ssgdeal/notification_service/presentation/internal/NotificationInternalController.java
@@ -4,12 +4,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import on.ssgdeal.common.auth.passport.Passport;
 import on.ssgdeal.common.auth.passport.PassportUtil;
 import on.ssgdeal.common.presentation.dto.CommonResponse;
 import on.ssgdeal.notification_service.application.service.NotificationServiceImpl;
-import on.ssgdeal.notification_service.presentation.internal.dto.CreateNotificationRequest;
 import on.ssgdeal.notification_service.application.service.dto.CreateNotificationResponseDto;
+import on.ssgdeal.notification_service.presentation.internal.dto.CreateNotificationRequest;
 import on.ssgdeal.notification_service.presentation.internal.dto.mapper.NotificationPresentationMapper;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,17 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class NotificationInternalController {
 
-    private final PassportUtil passportUtil;
     private final NotificationPresentationMapper notificationMapper;
     private final NotificationServiceImpl notificationServiceImpl;
 
     @PostMapping("/order/complete")
     public ResponseEntity<CommonResponse<CreateNotificationResponseDto>> createNotification(
-            @Valid @RequestBody final CreateNotificationRequest request
-//            HttpServletRequest servletRequest
+            @Valid @RequestBody final CreateNotificationRequest request,
+            HttpServletRequest servletRequest
     ) {
-//        Passport passport = passportUtil.getPassportBy(servletRequest);
-//        final var requestDto = notificationMapper.toNotificationRequestDto(request, passport.getSlackEmail());
         final var requestDto = notificationMapper.toNotificationRequestDto(request, "hyunj2034@naver.com");
         log.info("주문 완료 슬랙 메시지 요청 : {}", request);
         final var responseDto = notificationServiceImpl.sendSlackNotification(requestDto);

--- a/notification_service/src/main/resources/application.yml
+++ b/notification_service/src/main/resources/application.yml
@@ -12,13 +12,16 @@ spring:
       port: 1234
       username: username
       password: password
+  datasource:
+    url: jdbc:mysql://ec2-3-37-120-109.ap-northeast-2.compute.amazonaws.com:3306/on-rdb
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   cloud:
     config:
       discovery:
         enabled: true
         service-id: config-service
-  profiles:
-    active: dev
 
 eureka:
   client:

--- a/notification_service/src/test/java/on/ssgdeal/notification_service/application/service/NotificationServiceImplIntegrationTest.java
+++ b/notification_service/src/test/java/on/ssgdeal/notification_service/application/service/NotificationServiceImplIntegrationTest.java
@@ -1,13 +1,15 @@
 package on.ssgdeal.notification_service.application.service;
 
+import on.ssgdeal.common.auth.passport.Passport;
+import on.ssgdeal.common.auth.passport.PassportUtil;
 import on.ssgdeal.notification_service.application.service.dto.CreateNotificationRequestDto;
+import on.ssgdeal.notification_service.application.service.dto.CreateNotificationResponseDto;
 import on.ssgdeal.notification_service.domain.entity.Notification;
 import on.ssgdeal.notification_service.domain.entity.NotificationTemplate;
 import on.ssgdeal.notification_service.domain.enums.NotificationTemplateType;
 import on.ssgdeal.notification_service.domain.repository.NotificationRepository;
 import on.ssgdeal.notification_service.domain.repository.NotificationTemplateRepository;
 import on.ssgdeal.notification_service.infrastructure.client.slack.converter.SlackTimestampToKSTConverter;
-import on.ssgdeal.notification_service.application.service.dto.CreateNotificationResponseDto;
 import org.hibernate.AssertionFailure;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +27,7 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ActiveProfiles("dev")
@@ -34,6 +38,9 @@ public class NotificationServiceImplIntegrationTest {
 
     @Autowired
     private NotificationService notificationService;
+
+    @MockitoBean
+    private PassportUtil passportUtil;
 
     @MockitoBean
     private SlackClient slackClient;
@@ -54,9 +61,13 @@ public class NotificationServiceImplIntegrationTest {
     private String mockTimestamp;
     private LocalDateTime mockSendAt;
 
-
     @BeforeEach
     void setUp() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        Passport mockPassport = mock(Passport.class);
+        when(mockPassport.getUserId()).thenReturn(1000L);
+        when(passportUtil.getPassportBy(request)).thenReturn(mockPassport);
+
         mockRequestDto = CreateNotificationRequestDto.builder()
                 .receiverSlackEmail("hyunj2034@naver.com")
                 .senderSlackEmail("master@naver.com")

--- a/notification_service/src/test/java/on/ssgdeal/notification_service/application/service/NotificationServiceImplIntegrationTest.java
+++ b/notification_service/src/test/java/on/ssgdeal/notification_service/application/service/NotificationServiceImplIntegrationTest.java
@@ -1,12 +1,9 @@
 package on.ssgdeal.notification_service.application.service;
 
-import on.ssgdeal.common.auth.passport.Passport;
 import on.ssgdeal.common.auth.passport.PassportUtil;
 import on.ssgdeal.notification_service.application.service.dto.CreateNotificationRequestDto;
 import on.ssgdeal.notification_service.application.service.dto.CreateNotificationResponseDto;
 import on.ssgdeal.notification_service.domain.entity.Notification;
-import on.ssgdeal.notification_service.domain.entity.NotificationTemplate;
-import on.ssgdeal.notification_service.domain.enums.NotificationTemplateType;
 import on.ssgdeal.notification_service.domain.repository.NotificationRepository;
 import on.ssgdeal.notification_service.domain.repository.NotificationTemplateRepository;
 import on.ssgdeal.notification_service.infrastructure.client.slack.converter.SlackTimestampToKSTConverter;
@@ -17,20 +14,18 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ActiveProfiles("dev")
 @Transactional
 @SpringBootTest
 @DisplayName("NotificationServiceImpl 통합 테스트")
@@ -38,6 +33,9 @@ public class NotificationServiceImplIntegrationTest {
 
     @Autowired
     private NotificationService notificationService;
+
+    @MockitoBean
+    private AuditorAware<Long> auditorAware;
 
     @MockitoBean
     private PassportUtil passportUtil;
@@ -56,17 +54,12 @@ public class NotificationServiceImplIntegrationTest {
 
     private CreateNotificationRequestDto mockRequestDto;
 
-    private NotificationTemplate mockTemplate;
-
     private String mockTimestamp;
     private LocalDateTime mockSendAt;
 
     @BeforeEach
     void setUp() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        Passport mockPassport = mock(Passport.class);
-        when(mockPassport.getUserId()).thenReturn(1000L);
-        when(passportUtil.getPassportBy(request)).thenReturn(mockPassport);
+        when(auditorAware.getCurrentAuditor()).thenReturn(Optional.of(1000L));
 
         mockRequestDto = CreateNotificationRequestDto.builder()
                 .receiverSlackEmail("hyunj2034@naver.com")
@@ -78,16 +71,9 @@ public class NotificationServiceImplIntegrationTest {
                 .orderStatus("결제완료")
                 .build();
 
-        mockTemplate = NotificationTemplate.builder()
-                .type(NotificationTemplateType.ORDER_COMPLETED)
-                .content("주문자: {ordererName}\n주문번호: {orderId}\n결제금액: {paymentPrice}\n주문날짜: {orderAt}\n주문상태: {orderStatus}")
-                .build();
-
         mockTimestamp = "1744109481.123456";
 
         mockSendAt = LocalDateTime.of(2025, 4, 8, 19, 51, 21, 123456000);
-
-        notificationTemplateRepository.save(mockTemplate);
 
     }
 

--- a/notification_service/src/test/java/on/ssgdeal/notification_service/application/service/NotificationServiceImplIntegrationTest.java
+++ b/notification_service/src/test/java/on/ssgdeal/notification_service/application/service/NotificationServiceImplIntegrationTest.java
@@ -1,6 +1,5 @@
 package on.ssgdeal.notification_service.application.service;
 
-import on.ssgdeal.common.auth.passport.PassportUtil;
 import on.ssgdeal.notification_service.application.service.dto.CreateNotificationRequestDto;
 import on.ssgdeal.notification_service.application.service.dto.CreateNotificationResponseDto;
 import on.ssgdeal.notification_service.domain.entity.Notification;
@@ -36,9 +35,6 @@ public class NotificationServiceImplIntegrationTest {
 
     @MockitoBean
     private AuditorAware<Long> auditorAware;
-
-    @MockitoBean
-    private PassportUtil passportUtil;
 
     @MockitoBean
     private SlackClient slackClient;


### PR DESCRIPTION
## ✨ 변경 타입
* [ ] 신규 기능 추가/수정
* [x] 버그 수정
* [ ] 리팩토링
* [x] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [ ] 코드 작성 가이드라인을 준수했는가?
* [ ] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 변경 내용
* **as-is**
  * application-dev 설정으로 테스트
  * JpaAuditing 테스트 오류

* **to-be**
  * application 파일로 테스트 변경
  * AWS의 DB로 테스트 진행
  * JpaAuditorAware mock 추가


## 💡 추가 설명

  * DB 관련 설정 Secret Key로 레포지토리에 추가했습니다

## ⚡️ 관련 이슈

* PR과 관련된 이슈를 해시태그 형식으로 남겨주세요 (ex. #3)

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 알림 생성 시 사용자 식별을 위한 동적 이메일 추출을 제거하고, 고정된 이메일로 처리하도록 변경되었습니다.

- **환경 설정**
  - MySQL 데이터베이스 연결 정보가 추가되었습니다.
  - Spring 프로파일(dev) 관련 설정이 제거되었습니다.

- **테스트**
  - 테스트에서 불필요한 템플릿 설정이 제거되고, 감사자 정보(Auditor)가 고정값으로 모킹되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->