### PR TITLE
feature: 공통 모듈에 카프카 프로듀서 모듈 추가

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -25,6 +25,9 @@ dependencies {
     // spring cloud
     implementation platform("org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}")
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 // Lombok Annotation Processor 강제 적용

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
@@ -20,7 +20,6 @@ import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.ExponentialBackOffWithMaxRetries;
-import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 @Configuration
 @EnableKafka

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
@@ -105,6 +105,8 @@ public class KafkaConsumerConfig {
             .setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
         // DLQ 정책 및 재시도 정책 적용
         factory.setCommonErrorHandler(defaultErrorHandler);
+        // 컨테이너 동시성 설정
+        factory.setConcurrency(Runtime.getRuntime().availableProcessors());
 
         return factory;
     }

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import on.ssgdeal.common.messaging.exception.NonRecoverableException;
+import on.ssgdeal.common.messaging.producer.KafkaOutboxProducer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
 import org.apache.kafka.common.TopicPartition;
@@ -135,7 +136,7 @@ public class KafkaConsumerConfig {
         DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
             kafkaTemplate,
             // 기존 파티션과 DLQ 파티션의 차이가 존재할 수 있으므로 파티션 0 고정
-            (cr, ex) -> new TopicPartition(cr.topic() + ".DLT", 0)
+            (cr, ex) -> new TopicPartition(cr.topic() + KafkaOutboxProducer.DLT_SUFFIX, 0)
         );
         recoverer.setHeadersFunction((record, ex) -> {
             record.headers().add(

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
@@ -1,0 +1,152 @@
+package on.ssgdeal.common.messaging.config;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import on.ssgdeal.common.messaging.exception.NonRecoverableException;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.ExponentialBackOffWithMaxRetries;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> configs = getConsumerCommonConfigs();
+
+        return new DefaultKafkaConsumerFactory<>(
+            configs, new StringDeserializer(), new StringDeserializer());
+    }
+
+    private Map<String, Object> getConsumerCommonConfigs() {
+        Map<String, Object> configs = new HashMap<>();
+
+        // kafka 서버
+        configs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        // 컨슈머 그룹 내 여러 컨슈머의 메시지 중복 처리를 방지
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, "on-ssgdeal-group");
+
+        // key 역직렬화
+        configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        // value 역직렬화
+        configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        // 역직렬화 시 신뢰할 수 있는 패키지
+        configs.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+
+        // 자동 토픽 생성
+        configs.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
+        // offset 수동 커밋
+        configs.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        // 오프셋 초기화 시점
+        configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        // consumer offset 커밋 트랜잭션 격리 수준
+        configs.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+
+        // 리밸런싱 발생 시 컨슈머의 파티션 재분배 전략
+        // CooperativeStickyAssignor => 컨슈머들은 기존 파티션을 최대한 유지
+        configs.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
+            CooperativeStickyAssignor.class);
+
+        // 세션 타임아웃 (Default)
+        configs.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 45000);
+        // API 타임아웃 (Default)
+        configs.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, 60000);
+        // 요청 타임아웃 (Default)
+        configs.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000);
+        // 컨슈머 헬스체크 (Default / 3)
+        configs.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 1000);
+
+        // poll() 시 가져올 최대 레코드 수 (Default)
+        configs.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 500);
+        // poll() 간격 최대 시간 (Default)
+        configs.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 50000);
+
+        // 재연결 backoff 기본 ms (Default)
+        configs.put(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG, 50);
+        // 재연결 backoff 최대 ms (Default)
+        configs.put(ConsumerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, 1000);
+        // 재시도 backoff 기본 ms (Default)
+        configs.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, 100);
+        // 재시도 backoff 최대 ms (Default)
+        configs.put(ConsumerConfig.RETRY_BACKOFF_MAX_MS_CONFIG, 1000);
+
+        return configs;
+    }
+
+    @Bean(name = "kafkaListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+        DefaultErrorHandler defaultErrorHandler
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+
+        // 중복 방지를 위해 메시지 처리 완료시 즉시 offset 커밋
+        factory.getContainerProperties()
+            .setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        // DLQ 정책 및 재시도 정책 적용
+        factory.setCommonErrorHandler(defaultErrorHandler);
+
+        return factory;
+    }
+
+    @Bean
+    public DefaultErrorHandler errorHandler(KafkaTemplate<String, String> kafkaTemplate) {
+        DeadLetterPublishingRecoverer recoverer = getDeadLetterPublishingRecoverer(kafkaTemplate);
+
+        // 최대 반복 3번의 재시도 및 간격 지수 증가
+        ExponentialBackOffWithMaxRetries backoff = new ExponentialBackOffWithMaxRetries(3);
+        backoff.setInitialInterval(2000); // 2초
+        backoff.setMultiplier(2.0);       // 2배씩 증가
+        backoff.setMaxInterval(10000);    // 최대 10초
+
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backoff);
+
+        // IllegalArgumentException 은 재시도 하지 않고 바로 DLQ 로 보냄
+        errorHandler.addNotRetryableExceptions(
+            IllegalArgumentException.class,
+            NonRecoverableException.class
+        );
+
+        return errorHandler;
+    }
+
+    private DeadLetterPublishingRecoverer getDeadLetterPublishingRecoverer(
+        KafkaTemplate<String, String> kafkaTemplate
+    ) {
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+            kafkaTemplate,
+            // 기존 파티션과 DLQ 파티션의 차이가 존재할 수 있으므로 파티션 0 고정
+            (cr, ex) -> new TopicPartition(cr.topic() + ".DLT", 0)
+        );
+        recoverer.setHeadersFunction((record, ex) -> {
+            record.headers().add(
+                "Kafka_DLT_Reason", ex.getMessage().getBytes(StandardCharsets.UTF_8));
+            record.headers().add(
+                "Kafka_OriginalTimestamp", String.valueOf(record.timestamp()).getBytes());
+            return record.headers();
+        });
+        return recoverer;
+    }
+}

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
@@ -50,8 +50,6 @@ public class KafkaConsumerConfig {
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         // value 역직렬화
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        // 역직렬화 시 신뢰할 수 있는 패키지
-        configs.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
 
         // 자동 토픽 생성
         configs.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaProducerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaProducerConfig.java
@@ -1,0 +1,74 @@
+package on.ssgdeal.common.messaging.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        ProducerFactory<String, String> producerFactory = producerFactory();
+
+        return new KafkaTemplate<>(producerFactory);
+    }
+
+    private ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configs = getProducerCommonConfigs();
+
+        return new DefaultKafkaProducerFactory<>(configs);
+    }
+
+    private Map<String, Object> getProducerCommonConfigs() {
+        Map<String, Object> configs = new HashMap<>();
+
+        // kafka 서버
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        // key 직렬화
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+            StringSerializer.class);
+        // value 직렬화
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+            StringSerializer.class);
+
+        //== Exactly-once 핵심 설정
+        // 메시지 중복 방지를 위한 멱등성 설정 => 멱등성 활성화 시 acks=all 자동 설정됨 (Kafka 2.1+)
+        configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        // 모든 브로커가 메시지를 수신했을 때 응답
+        configs.put(ProducerConfig.ACKS_CONFIG, "all");
+        // 단일 브로커 연결당 동시 전송 가능한 미확인(unacknowledged) 요청의 최대 개수 ( 멱등성 활성화 필수 )
+        configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
+        // 트랜잭션 타임아웃
+        configs.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, 300000);
+
+        //== 성능 튜닝
+        // batch size (32KB)
+        configs.put(ProducerConfig.BATCH_SIZE_CONFIG, 32768);
+        // 메시지 발행 지연 시간
+        configs.put(ProducerConfig.LINGER_MS_CONFIG, 100);
+        // 전송 타임아웃  ( >= 요청 타임아웃 + 발행 지연 시간 )
+        configs.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 60000);
+        // 요청 타임아웃 (Default)
+        configs.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000);
+        // 재연결 지연 시간 (Default)
+        configs.put(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG, 50);
+        // 재시도 지연 시간 (Default)
+        configs.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 100);
+        // 재시도 최대 지연 시간 (Default)
+        configs.put(ProducerConfig.RETRY_BACKOFF_MAX_MS_CONFIG, 1000);
+
+        return configs;
+    }
+}

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaProducerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaProducerConfig.java
@@ -24,7 +24,8 @@ public class KafkaProducerConfig {
         return new KafkaTemplate<>(producerFactory);
     }
 
-    private ProducerFactory<String, String> producerFactory() {
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
         Map<String, Object> configs = getProducerCommonConfigs();
 
         return new DefaultKafkaProducerFactory<>(configs);

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaProducerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaProducerConfig.java
@@ -16,6 +16,8 @@ public class KafkaProducerConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
+    @Value("${spring.application.name}")
+    private String applicationName;
 
     @Bean
     public KafkaTemplate<String, String> kafkaTemplate() {
@@ -53,6 +55,8 @@ public class KafkaProducerConfig {
         configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
         // 트랜잭션 타임아웃
         configs.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, 300000);
+        // 동일 Producer 재시작 간에도 트랜잭션을 식별하기 위한 ID
+        configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "tx-ssgdeal-" + applicationName);
 
         //== 성능 튜닝
         // batch size (32KB)

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaTopicConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaTopicConfig.java
@@ -1,0 +1,17 @@
+package on.ssgdeal.common.messaging.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.KafkaAdmin.NewTopics;
+
+@Configuration
+@EnableKafka
+public class KafkaTopicConfig {
+
+    @Bean
+    public NewTopics newTopics() {
+        return new NewTopics(
+        );
+    }
+}

--- a/common/src/main/java/on/ssgdeal/common/messaging/domain/entity/Outbox.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/domain/entity/Outbox.java
@@ -22,6 +22,8 @@ import org.hibernate.annotations.SQLRestriction;
 @SQLRestriction("success = false")
 public class Outbox {
 
+    private static final int MAX_RETRY_COUNT = 3;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -61,7 +63,7 @@ public class Outbox {
     }
 
     public boolean isOverRetryCount() {
-        return this.retryCount > 3;
+        return this.retryCount > MAX_RETRY_COUNT;
     }
 
     public void success() {

--- a/common/src/main/java/on/ssgdeal/common/messaging/domain/entity/Outbox.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/domain/entity/Outbox.java
@@ -1,0 +1,76 @@
+package on.ssgdeal.common.messaging.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@SQLRestriction("success = false")
+public class Outbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private AggregateType aggregateType;
+
+    private Long aggregateId;
+
+    @Column(columnDefinition = "TEXT")
+    private String payload;
+
+    private String topic;
+
+    private int retryCount;
+
+    private boolean success;
+
+    public static Outbox create(
+        String topic,
+        AggregateType aggregateType,
+        Long aggregateId,
+        String payload
+    ) {
+        return Outbox.builder()
+            .topic(topic)
+            .aggregateType(aggregateType)
+            .aggregateId(aggregateId)
+            .payload(payload)
+            .retryCount(0)
+            .success(false)
+            .build();
+    }
+
+    public void increaseRetryCount() {
+        this.retryCount++;
+    }
+
+    public boolean isOverRetryCount() {
+        return this.retryCount > 3;
+    }
+
+    public void success() {
+        this.success = true;
+    }
+
+    public enum AggregateType {
+        ORDER,
+        PAYMENT,
+        ;
+    }
+}

--- a/common/src/main/java/on/ssgdeal/common/messaging/domain/repository/OutboxRepository.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/domain/repository/OutboxRepository.java
@@ -1,0 +1,11 @@
+package on.ssgdeal.common.messaging.domain.repository;
+
+import java.util.List;
+import on.ssgdeal.common.messaging.domain.entity.Outbox;
+import on.ssgdeal.common.messaging.domain.entity.Outbox.AggregateType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboxRepository extends JpaRepository<Outbox, Long> {
+
+    List<Outbox> findByAggregateType(AggregateType aggregateType);
+}

--- a/common/src/main/java/on/ssgdeal/common/messaging/producer/KafkaOutboxProducer.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/producer/KafkaOutboxProducer.java
@@ -30,7 +30,7 @@ public class KafkaOutboxProducer {
                     if (outbox.isOverRetryCount()) {
                         log.error("재시도 횟수를 초과하여 메시지 발행을 실패했습니다. => id: {}",
                             outbox.getId());
-                        kafkaTemplate.send(topic + DLT_SUFFIX, payload);
+                        kafkaTemplate.send(topic + DLT_SUFFIX, key, payload);
                     }
                 } else {
                     outbox.success();

--- a/common/src/main/java/on/ssgdeal/common/messaging/producer/KafkaOutboxProducer.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/producer/KafkaOutboxProducer.java
@@ -1,0 +1,41 @@
+package on.ssgdeal.common.messaging.producer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import on.ssgdeal.common.messaging.domain.entity.Outbox;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaOutboxProducer {
+
+    public static final String DLT_SUFFIX = ".dlt";
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    // 단일 메시지 발행
+    public void publishOutboxMessage(Outbox outbox) {
+        String topic = outbox.getTopic();
+        String key = String.valueOf(outbox.getAggregateId());
+        String payload = outbox.getPayload();
+
+        kafkaTemplate.send(topic, key, payload)
+            .handle((res, ex) -> {
+                if (ex != null) {
+                    log.error("메시지 발행을 실패했습니다. => id: {}, retryCount: {}",
+                        outbox.getId(), outbox.getRetryCount());
+                    outbox.increaseRetryCount();
+                    if (outbox.isOverRetryCount()) {
+                        log.error("재시도 횟수를 초과하여 메시지 발행을 실패했습니다. => id: {}",
+                            outbox.getId());
+                        kafkaTemplate.send(topic + DLT_SUFFIX, payload);
+                    }
+                } else {
+                    outbox.success();
+                }
+                return outbox;
+            });
+    }
+}


### PR DESCRIPTION
## ✨ 변경 타입
* [X] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [ ] 코드 작성 가이드라인을 준수했는가?
* [ ] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 변경 내용
* **as-is**
  * N/A

* **to-be**
  * 토픽, 컨슈머, 프로듀서 설정 추가
  * 카프카 아웃박스 프로듀서 공통 로직 구현

## 💡 추가 설명

* 이후 컨슈머 공통 로직과 프로듀서 로직을 추가해야 합니다.
* 프로듀서의 트랜잭션 id에 대한 설정을 추가해야 합니다.

## ⚡️ 관련 이슈

* 

## 📚 참고 자료 (선택 사항)

* 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - Apache Kafka 지원이 추가되어 메시지 송수신 기능이 제공됩니다.
    - Outbox 엔터티 및 저장소가 도입되어 메시지의 신뢰성 있는 비동기 처리와 재시도, 성공 여부 추적이 가능합니다.
    - Kafka 프로듀서 및 컨슈머 설정이 추가되어 정확히 한 번만 전송(Exactly-once) 및 데드레터 큐(Dead Letter Queue) 처리가 지원됩니다.
    - Outbox 메시지를 Kafka로 발행하는 프로듀서 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->