### PR TITLE
feature: order service kafka migration 추가 수정

### DIFF
--- a/common/src/main/java/on/ssgdeal/common/jpa/JpaAuditingConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/jpa/JpaAuditingConfig.java
@@ -18,6 +18,9 @@ public class JpaAuditingConfig {
     public AuditorAware<Long> loginUserAuditorAware() {
         return () -> {
             String userId = MDC.get(MdcKey.USER_ID.getKey());
+            if (userId == null || userId.isEmpty()) {
+                return Optional.empty();
+            }
             return Optional.of(Long.parseLong(userId));
         };
     }

--- a/common/src/main/java/on/ssgdeal/common/mdc/PassportMdcContext.java
+++ b/common/src/main/java/on/ssgdeal/common/mdc/PassportMdcContext.java
@@ -14,8 +14,6 @@ public class PassportMdcContext implements AutoCloseable {
     }
 
     private void inject(String passportId) {
-        MDC.clear();
-
         Passport passport = passportUtil.getPassportBy(passportId);
 
         MDC.put(MdcKey.PASSPORT_ID.getKey(), passportId);

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
@@ -26,6 +26,8 @@ public class KafkaConsumerConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
+    @Value("${spring.application.name}")
+    private String applicationName;
 
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {
@@ -42,7 +44,7 @@ public class KafkaConsumerConfig {
         configs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 
         // 컨슈머 그룹 내 여러 컨슈머의 메시지 중복 처리를 방지
-        configs.put(ConsumerConfig.GROUP_ID_CONFIG, "on-ssgdeal-group");
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, "ssgdeal-group-" + applicationName);
 
         // key 역직렬화
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaProducerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaProducerConfig.java
@@ -57,10 +57,12 @@ public class KafkaProducerConfig {
         // 트랜잭션 타임아웃
         configs.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, 300000);
         // 재시도 횟수
-        configs.put(ProducerConfig.RETRIES_CONFIG, 3);
+        configs.put(ProducerConfig.RETRIES_CONFIG, 5);
         // 동일 Producer 재시작 간에도 트랜잭션을 식별하기 위한 ID
         configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG,
-            "tx-ssgdeal-" + applicationName + UUID.randomUUID());
+            "tx-ssgdeal-" + applicationName
+                + System.getProperty("instance.id", "default")
+                + "-" + UUID.randomUUID());
 
         //== 성능 튜닝
         // batch size (32KB)

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaTopicConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaTopicConfig.java
@@ -1,5 +1,7 @@
 package on.ssgdeal.common.messaging.config;
 
+import static on.ssgdeal.common.messaging.config.KafkaConsumerConfig.DLT_SUFFIX;
+
 import on.ssgdeal.common.messaging.domain.enums.Topic;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.context.annotation.Bean;
@@ -10,8 +12,6 @@ import org.springframework.kafka.core.KafkaAdmin.NewTopics;
 @Configuration
 @EnableKafka
 public class KafkaTopicConfig {
-
-    private static final String DLT_SUFFIX = ".dlt";
 
     @Bean
     public NewTopics newTopics() {

--- a/common/src/main/java/on/ssgdeal/common/messaging/core/EventEnvelope.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/core/EventEnvelope.java
@@ -18,6 +18,13 @@ public record EventEnvelope<T extends EventPayload>(
     String timestamp
 ) {
 
+    private static final ObjectMapper OBJECT_MAPPER;
+
+    static {
+        OBJECT_MAPPER = new ObjectMapper();
+        OBJECT_MAPPER.registerModule(new JavaTimeModule());
+    }
+
     public static <T extends EventPayload> EventEnvelope<T> wrap(
         String topic, String passportId, T payload, String timestamp
     ) {
@@ -31,9 +38,8 @@ public record EventEnvelope<T extends EventPayload>(
     }
 
     public String toJson() {
-        ObjectMapper objectMapper = getObjectMapper();
         try {
-            return objectMapper.writeValueAsString(this);
+            return OBJECT_MAPPER.writeValueAsString(this);
         } catch (JsonProcessingException e) {
             log.error("EventEnvelope 의 직렬화를 실패했습니다. => {}", e.getMessage());
             throw new EventSerializeException();
@@ -41,26 +47,19 @@ public record EventEnvelope<T extends EventPayload>(
     }
 
     public static <T extends EventPayload> EventEnvelope<T> fromJson(String json, Class<T> tClass) {
-        ObjectMapper mapper = getObjectMapper();
         try {
-            JsonNode jsonNode = mapper.readTree(json);
+            JsonNode jsonNode = OBJECT_MAPPER.readTree(json);
             log.info("Envelope Json 역직렬화 시작 - jsonNode: {}", jsonNode);
 
             String topic = jsonNode.get("topic").asText();
             String timestamp = jsonNode.get("timestamp").asText();
             String passportId = jsonNode.get("passportId").asText();
-            T payload = mapper.treeToValue(jsonNode.get("payload"), tClass);
+            T payload = OBJECT_MAPPER.treeToValue(jsonNode.get("payload"), tClass);
 
             return EventEnvelope.wrap(topic, passportId, payload, timestamp);
         } catch (Exception e) {
             log.error("Envelope JSON 역직렬화 실패", e);
             throw new EventDeserializeException();
         }
-    }
-
-    private static ObjectMapper getObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        return mapper;
     }
 }

--- a/common/src/main/java/on/ssgdeal/common/messaging/core/EventEnvelope.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/core/EventEnvelope.java
@@ -47,9 +47,9 @@ public record EventEnvelope<T extends EventPayload>(
     }
 
     public static <T extends EventPayload> EventEnvelope<T> fromJson(String json, Class<T> tClass) {
+        log.debug("Envelope Json 역직렬화 시작");
         try {
             JsonNode jsonNode = OBJECT_MAPPER.readTree(json);
-            log.info("Envelope Json 역직렬화 시작 - jsonNode: {}", jsonNode);
 
             String topic = jsonNode.get("topic").asText();
             String timestamp = jsonNode.get("timestamp").asText();
@@ -57,6 +57,12 @@ public record EventEnvelope<T extends EventPayload>(
             T payload = OBJECT_MAPPER.treeToValue(jsonNode.get("payload"), tClass);
 
             return EventEnvelope.wrap(topic, passportId, payload, timestamp);
+        } catch (JsonProcessingException e) {
+            log.error("JSON 처리 오류: Envelope JSON 역직렬화 실패", e);
+            throw new EventDeserializeException();
+        } catch (NullPointerException e) {
+            log.error("필드 누락 오류: Envelope JSON 역직렬화 실패", e);
+            throw new EventDeserializeException();
         } catch (Exception e) {
             log.error("Envelope JSON 역직렬화 실패", e);
             throw new EventDeserializeException();

--- a/common/src/main/java/on/ssgdeal/common/messaging/exception/MessagingExceptionCode.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/exception/MessagingExceptionCode.java
@@ -10,8 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum MessagingExceptionCode implements ExceptionCode {
 
     NON_RECOVERABLE(HttpStatus.CONFLICT, "재시도 하지 않을 예외가 발생했습니다."),
-    EVENT_JSON_DESERIALIZE_EXCEPTION(HttpStatus.NOT_MODIFIED, "이벤트 역직렬화에 실패했습니다."),
-    EVENT_JSON_SERIALIZE_EXCEPTION(HttpStatus.NOT_MODIFIED, "이벤트 직렬화에 실패했습니다."),
+    EVENT_JSON_DESERIALIZE_EXCEPTION(HttpStatus.BAD_REQUEST, "이벤트 역직렬화에 실패했습니다."),
+    EVENT_JSON_SERIALIZE_EXCEPTION(HttpStatus.BAD_REQUEST, "이벤트 직렬화에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/notification_service/src/main/java/on/ssgdeal/notification_service/infrastructure/client/slack/SlackClientImpl.java
+++ b/notification_service/src/main/java/on/ssgdeal/notification_service/infrastructure/client/slack/SlackClientImpl.java
@@ -25,7 +25,7 @@ public class SlackClientImpl implements SlackClient {
      * 슬랙 이메일로 슬랙 유저 ID 조회
      */
     public String getSlackIdByEmail(String email) {
-        log.info("getSlackIdByEmail: {},", email);
+        log.debug("getSlackIdByEmail: {}", email.replaceAll("(?<=.{3}).(?=.*@)", "*"));
         JsonNode response = slackWebClient.get()
             .uri(uriBuilder -> uriBuilder
                 .path(LOOKUP_BY_SLACK_EMAIL_URL)
@@ -67,7 +67,9 @@ public class SlackClientImpl implements SlackClient {
      * 메시지 전송
      */
     public String sendNotificationToUser(String email, String content) {
-        log.info("sendNotificationToUser: {}, {}", email, content);
+        log.debug("sendNotificationToUser: {}, length of content: {}",
+            email.replaceAll("(?<=.{3}).(?=.*@)", "*"),
+            content != null ? content.length() : 0);
         try {
             String userId = getSlackIdByEmail(email);
             String channelId = getChannelIdByUserId(userId);

--- a/notification_service/src/main/java/on/ssgdeal/notification_service/infrastructure/messaging/consumer/NotificationKafkaEventListener.java
+++ b/notification_service/src/main/java/on/ssgdeal/notification_service/infrastructure/messaging/consumer/NotificationKafkaEventListener.java
@@ -50,7 +50,7 @@ public class NotificationKafkaEventListener {
             log.error("재시도하지 않을 예외가 발생했습니다. => {}", nre.getMessage());
             throw nre;
         } catch (Exception e) {
-            log.error("재시도할 예외가 발생했습니다. => {}", e.getMessage());
+            log.error("재시도할 예외가 발생했습니다.", e);
             throw new RuntimeException(e);
         }
     }
@@ -60,7 +60,7 @@ public class NotificationKafkaEventListener {
             notificationService.sendNotification(payload.toDto(), NotificationChannelType.SLACK);
             ack.acknowledge();
         } catch (Exception e) {
-            log.error("메시지 소비에 실패했습니다. => {}", e.getMessage());
+            log.error("메시지 소비에 실패했습니다.", e);
             throw e;
         }
     }

--- a/notification_service/src/main/java/on/ssgdeal/notification_service/infrastructure/messaging/consumer/NotificationKafkaEventListener.java
+++ b/notification_service/src/main/java/on/ssgdeal/notification_service/infrastructure/messaging/consumer/NotificationKafkaEventListener.java
@@ -35,7 +35,7 @@ public class NotificationKafkaEventListener {
         @Payload String message,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         Acknowledgment ack
-    ) {
+    ) throws Exception {
         log.info("메시지를 소비합니다. Topic : {}, message :{}", topic, message);
         EventEnvelope<CreateNotificationEvent> envelope =
             EventEnvelope.fromJson(message, CreateNotificationEvent.class);
@@ -51,7 +51,7 @@ public class NotificationKafkaEventListener {
             throw nre;
         } catch (Exception e) {
             log.error("재시도할 예외가 발생했습니다.", e);
-            throw new RuntimeException(e);
+            throw e;
         }
     }
 

--- a/notification_service/src/main/java/on/ssgdeal/notification_service/infrastructure/messaging/consumer/NotificationKafkaEventListener.java
+++ b/notification_service/src/main/java/on/ssgdeal/notification_service/infrastructure/messaging/consumer/NotificationKafkaEventListener.java
@@ -34,9 +34,13 @@ public class NotificationKafkaEventListener {
     public void listenSuccessOrderEvent(
         @Payload String message,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+        @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+        @Header(KafkaHeaders.OFFSET) long offset,
+        @Header(name = KafkaHeaders.RECEIVED_KEY, required = false) Integer key,
         Acknowledgment ack
     ) throws Exception {
-        log.info("메시지를 소비합니다. Topic : {}, message :{}", topic, message);
+        log.info("메시지를 소비합니다. Topic : {}, Partition: {}, Offset: {}, Message key :{}",
+            topic, partition, offset, key);
         EventEnvelope<CreateNotificationEvent> envelope =
             EventEnvelope.fromJson(message, CreateNotificationEvent.class);
 

--- a/promotion_service/src/main/java/on/ssgdeal/promotion_service/infrastructure/messaging/consumer/ProductKafkaEventListener.java
+++ b/promotion_service/src/main/java/on/ssgdeal/promotion_service/infrastructure/messaging/consumer/ProductKafkaEventListener.java
@@ -34,7 +34,7 @@ public class ProductKafkaEventListener {
         @Payload String message,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         Acknowledgment ack
-    ) {
+    ) throws Exception {
         log.info("메시지를 소비합니다. Topic : {}, message :{}", topic, message);
         EventEnvelope<IncreaseStockEvent> envelope =
             EventEnvelope.fromJson(message, IncreaseStockEvent.class);
@@ -50,7 +50,7 @@ public class ProductKafkaEventListener {
             throw nre;
         } catch (Exception e) {
             log.error("재시도할 예외가 발생했습니다. => {}", e.getMessage());
-            throw new RuntimeException(e);
+            throw e;
         }
     }
 

--- a/promotion_service/src/main/java/on/ssgdeal/promotion_service/infrastructure/messaging/consumer/ProductKafkaEventListener.java
+++ b/promotion_service/src/main/java/on/ssgdeal/promotion_service/infrastructure/messaging/consumer/ProductKafkaEventListener.java
@@ -33,9 +33,13 @@ public class ProductKafkaEventListener {
     public void listenIncreaseStockEvent(
         @Payload String message,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+        @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+        @Header(KafkaHeaders.OFFSET) long offset,
+        @Header(name = KafkaHeaders.RECEIVED_KEY, required = false) Integer key,
         Acknowledgment ack
     ) throws Exception {
-        log.info("메시지를 소비합니다. Topic : {}, message :{}", topic, message);
+        log.info("메시지를 소비합니다. Topic : {}, Partition: {}, Offset: {}, Message key :{}",
+            topic, partition, offset, key);
         EventEnvelope<IncreaseStockEvent> envelope =
             EventEnvelope.fromJson(message, IncreaseStockEvent.class);
 


### PR DESCRIPTION
## ✨ 변경 타입
* [X] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [ ] 코드 작성 가이드라인을 준수했는가?
* [ ] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 변경 내용
* **as-is**
  * 

* **to-be**
  * 멋지다

## 💡 추가 설명

* 코드 리뷰 시 특별히 참고해야 할 부분이 있다면 언급해주세요.
* 궁금한 점이나 논의하고 싶은 내용이 있다면 작성해주세요.

## ⚡️ 관련 이슈

* PR과 관련된 이슈를 해시태그 형식으로 남겨주세요 (ex. #3)

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- Kafka 컨슈머 및 프로듀서 설정에서 애플리케이션 이름과 인스턴스 ID를 기반으로 그룹 ID 및 트랜잭션 ID가 동적으로 생성됩니다.

- **버그 수정**
	- 사용자 ID가 없거나 비어 있을 때 JPA 감사 로직에서 예외가 발생하지 않도록 처리되었습니다.
	- Kafka 이벤트 역직렬화/직렬화 예외의 HTTP 상태 코드가 400(BAD_REQUEST)으로 변경되었습니다.

- **리팩터링**
	- EventEnvelope의 JSON 직렬화/역직렬화가 단일 ObjectMapper 인스턴스를 사용하도록 개선되었습니다.
	- Kafka DLT 토픽 접미사 상수가 중앙에서 관리되도록 통합되었습니다.

- **스타일/로깅 개선**
	- Slack 관련 로그에서 이메일이 마스킹 처리되고, 메시지 내용 대신 길이만 로그로 남겨집니다.
	- Kafka 이벤트 리스너에서 메시지 본문 대신 파티션, 오프셋, 키 등 메타데이터가 로그됩니다.
	- 예외 발생 시 전체 스택트레이스가 로그로 출력됩니다.

- **기타**
	- MDC 컨텍스트에 패스포트 정보를 주입할 때 기존 컨텍스트를 초기화하지 않도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->