### PR TITLE
fix: 패스포트 필터가 적용되지 말아야 할 부분에도 적용되는 문제 수정

### DIFF
--- a/common/src/main/java/on/ssgdeal/common/web/filter/PassportFilter.java
+++ b/common/src/main/java/on/ssgdeal/common/web/filter/PassportFilter.java
@@ -57,7 +57,7 @@ public class PassportFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
         String method = request.getMethod();
 
-        log.info("uri, method: {}, {}", uri, method);
+        log.debug("uri, method: {}, {}", uri, method);
 
         return isCreateUserRequest(uri, method)
             || isSignupAuthRequest(uri, method)

--- a/common/src/main/java/on/ssgdeal/common/web/filter/PassportFilter.java
+++ b/common/src/main/java/on/ssgdeal/common/web/filter/PassportFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import on.ssgdeal.common.auth.passport.PassportUtil;
 import on.ssgdeal.common.mdc.PassportMdcContext;
 import org.springframework.stereotype.Component;
@@ -13,9 +14,41 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j(topic = "PassportFilter")
 public class PassportFilter extends OncePerRequestFilter {
 
     private final PassportUtil passportUtil;
+
+    private static boolean isInternalFindUserRequest(String uri, String method) {
+        return uri.contains("/internal")
+            && uri.contains("/users")
+            && method.equals("GET");
+    }
+
+    private static boolean isCreateUserRequest(String uri, String method) {
+        return uri.contains("/internal")
+            && uri.contains("/users")
+            && method.equals("POST");
+    }
+
+    private static boolean isValidateRequest(String uri, String method) {
+        return uri.contains("/internal")
+            && uri.contains("/auth")
+            && uri.contains("/validate")
+            && method.equals("GET");
+    }
+
+    private static boolean isSignupAuthRequest(String uri, String method) {
+        return uri.contains("/api")
+            && uri.contains("/auth/signup")
+            && method.equals("POST");
+    }
+
+    private static boolean isLoginAuthRequest(String uri, String method) {
+        return uri.contains("/api")
+            && uri.contains("/auth/login")
+            && method.equals("POST");
+    }
 
     @Override
     protected boolean shouldNotFilter(
@@ -24,9 +57,13 @@ public class PassportFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
         String method = request.getMethod();
 
+        log.info("uri, method: {}, {}", uri, method);
+
         return isCreateUserRequest(uri, method)
             || isSignupAuthRequest(uri, method)
-            || isLoginAuthRequest(uri, method);
+            || isLoginAuthRequest(uri, method)
+            || isInternalFindUserRequest(uri, method)
+            || isValidateRequest(uri, method);
     }
 
     @Override
@@ -44,23 +81,5 @@ public class PassportFilter extends OncePerRequestFilter {
         } catch (Exception e) {
             throw new ServletException("Passport Filter processing failed - " + e.getMessage(), e);
         }
-    }
-
-    private static boolean isCreateUserRequest(String uri, String method) {
-        return uri.contains("/internal")
-            && uri.contains("/users")
-            && method.equals("POST");
-    }
-
-    private static boolean isSignupAuthRequest(String uri, String method) {
-        return uri.contains("/api")
-            && uri.contains("/auth/signup")
-            && method.equals("POST");
-    }
-
-    private static boolean isLoginAuthRequest(String uri, String method) {
-        return uri.contains("/api")
-            && uri.contains("/auth/login")
-            && method.equals("POST");
     }
 }


### PR DESCRIPTION

## ✨ 변경 타입
* [ ] 신규 기능 추가/수정
* [X] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [X] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 변경 내용
* **as-is**
  * 패스포트 필터가 적용되지 말아야 할 부분에 적용돼 인증 객체가 없는 상태에서 인증 정보를 저장하려 해 버그 발생

* **to-be**
  * 버그 해결!

## 💡 추가 설명

* 코드 리뷰 시 특별히 참고해야 할 부분이 있다면 언급해주세요.
* 궁금한 점이나 논의하고 싶은 내용이 있다면 작성해주세요.

## ⚡️ 관련 이슈

* PR과 관련된 이슈를 해시태그 형식으로 남겨주세요 (ex. #3)

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 특정 요청 유형(GET `/internal/users`, GET `/internal/auth/validate`)에 대해 필터가 올바르게 우회되도록 개선되었습니다.
- **기타**
  - 요청 URI와 메서드가 정보 수준으로 로깅되어 추적이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->