### PR TITLE
refactor: Outbox 메시지 발행 비동기 처리 로직 개선

### DIFF
--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaConsumerConfig.java
@@ -53,19 +53,20 @@ public class KafkaConsumerConfig {
 
         // 자동 토픽 생성
         configs.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
+
+        //== Exactly-once 핵심 설정
         // offset 수동 커밋
         configs.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         // 오프셋 초기화 시점
         configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-
         // consumer offset 커밋 트랜잭션 격리 수준
         configs.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
-
         // 리밸런싱 발생 시 컨슈머의 파티션 재분배 전략
         // CooperativeStickyAssignor => 컨슈머들은 기존 파티션을 최대한 유지
         configs.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
             "org.apache.kafka.clients.consumer.CooperativeStickyAssignor");
 
+        //== 성능 튜닝
         // 세션 타임아웃 (Default)
         configs.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 45000);
         // API 타임아웃 (Default)

--- a/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaProducerConfig.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/config/KafkaProducerConfig.java
@@ -61,7 +61,6 @@ public class KafkaProducerConfig {
         // 동일 Producer 재시작 간에도 트랜잭션을 식별하기 위한 ID
         configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG,
             "tx-ssgdeal-" + applicationName
-                + System.getProperty("instance.id", "default")
                 + "-" + UUID.randomUUID());
 
         //== 성능 튜닝

--- a/common/src/main/java/on/ssgdeal/common/messaging/producer/KafkaOutboxProducer.java
+++ b/common/src/main/java/on/ssgdeal/common/messaging/producer/KafkaOutboxProducer.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import on.ssgdeal.common.messaging.config.KafkaConsumerConfig;
 import on.ssgdeal.common.messaging.domain.entity.Outbox;
-import on.ssgdeal.common.messaging.domain.repository.OutboxRepository;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,25 +18,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class KafkaOutboxProducer {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
-    private final OutboxRepository outboxRepository;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.READ_COMMITTED)
     public void publishOutboxMessages(List<Outbox> outboxeList) {
         List<CompletableFuture<Outbox>> completableFutures = outboxeList.stream()
             .map(this::publishOutboxMessage)
             .toList();
 
-        CompletableFuture.allOf(completableFutures.toArray(new CompletableFuture[0]))
-            .thenRun(() -> {
-                List<Outbox> updatedOutbox = completableFutures.stream()
-                    .map(CompletableFuture::join)
-                    .toList();
-                log.info("아웃박스 데이터 {}개의 메시지를 발행했습니다.", updatedOutbox.size());
-                outboxRepository.saveAll(updatedOutbox);
-            }).exceptionally(ex -> {
-                log.error("아웃박스 메시지 발행 중 예외가 발생했습니다. {}", ex.getMessage());
-                return null;
-            });
+        try {
+            CompletableFuture.allOf(completableFutures.toArray(new CompletableFuture[0]));
+        } catch (Exception e) {
+            log.error("메시지 발행 중 오류가 발생했습니다.", e);
+        }
+        List<Outbox> completedOutbox = completableFutures.stream()
+            .map(CompletableFuture::join)
+            .toList();
+        log.info("메시지 발행 완료. => size: {}", completedOutbox.size());
     }
 
     private CompletableFuture<Outbox> publishOutboxMessage(Outbox outbox) {

--- a/notification_service/src/main/java/on/ssgdeal/notification_service/infrastructure/messaging/consumer/NotificationKafkaEventListener.java
+++ b/notification_service/src/main/java/on/ssgdeal/notification_service/infrastructure/messaging/consumer/NotificationKafkaEventListener.java
@@ -28,7 +28,7 @@ public class NotificationKafkaEventListener {
 
     @KafkaListener(
         topics = {Topic.ORDER_SUCCESS_NOTIFICATION_EVENT},
-        groupId = "on-ssgdeal-group",
+        groupId = "on-ssgdeal-group-order-success-notification",
         containerFactory = "kafkaListenerContainerFactory"
     )
     public void listenSuccessOrderEvent(
@@ -49,7 +49,8 @@ public class NotificationKafkaEventListener {
             MdcContext mdcContext = new MdcContext();
             PassportMdcContext passportMdcContext = new PassportMdcContext(passportUtil, passportId);
         ) {
-            consumeSuccessOrderEvent(ack, envelope.payload());
+            consumeSuccessOrderEvent(envelope.payload());
+            ack.acknowledge();
         } catch (NonRecoverableException nre) {
             log.error("재시도하지 않을 예외가 발생했습니다. => {}", nre.getMessage());
             throw nre;
@@ -59,10 +60,9 @@ public class NotificationKafkaEventListener {
         }
     }
 
-    private void consumeSuccessOrderEvent(Acknowledgment ack, CreateNotificationEvent payload) {
+    private void consumeSuccessOrderEvent(CreateNotificationEvent payload) {
         try {
             notificationService.sendNotification(payload.toDto(), NotificationChannelType.SLACK);
-            ack.acknowledge();
         } catch (Exception e) {
             log.error("메시지 소비에 실패했습니다.", e);
             throw e;

--- a/promotion_service/src/main/java/on/ssgdeal/promotion_service/infrastructure/messaging/consumer/ProductKafkaEventListener.java
+++ b/promotion_service/src/main/java/on/ssgdeal/promotion_service/infrastructure/messaging/consumer/ProductKafkaEventListener.java
@@ -48,7 +48,8 @@ public class ProductKafkaEventListener {
             MdcContext mdcContext = new MdcContext();
             PassportMdcContext passportMdcContext = new PassportMdcContext(passportUtil, passportId);
         ) {
-            consumeIncreaseStockEvent(ack, envelope.payload());
+            consumeIncreaseStockEvent(envelope.payload());
+            ack.acknowledge();
         } catch (NonRecoverableException nre) {
             log.error("재시도하지 않을 예외가 발생했습니다. => {}", nre.getMessage());
             throw nre;
@@ -58,10 +59,9 @@ public class ProductKafkaEventListener {
         }
     }
 
-    private void consumeIncreaseStockEvent(Acknowledgment ack, IncreaseStockEvent payload) {
+    private void consumeIncreaseStockEvent(IncreaseStockEvent payload) {
         try {
             productService.increaseStock(payload.toDto());
-            ack.acknowledge();
         } catch (Exception e) {
             log.error("메시지 소비에 실패했습니다. => {}", e.getMessage());
             throw e;


### PR DESCRIPTION
## ✨ 변경 타입
* [ ] 신규 기능 추가/수정
* [ ] 버그 수정
* [X] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [ ] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 변경 내용
* **as-is**
  * 메인 스레드가 아닌 곳에서의 불필요한 트랜잭셔널 어노테이션 사용

* **to-be**
  * 메인 스레드에서만 트랜잭션 사용 및 비동기 병렬처리 로직 개선

## 💡 추가 설명

## ⚡️ 관련 이슈

## 📚 참고 자료 (선택 사항)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
    - Kafka 메시지 리스너에서 메시지 확인(acknowledgment) 시점을 이벤트 처리 후로 이동하여 처리 안정성을 향상시켰습니다.
    - Kafka 리스너의 그룹 ID가 더 명확하게 지정되었습니다.

- **리팩터**
    - 일부 내부 트랜잭션 처리 및 비동기 처리 로직이 단순화되고, 불필요한 저장소 의존성이 제거되었습니다.
    - 코드 내 주석이 추가되어 설정 구간이 명확히 구분됩니다.

- **스타일**
    - 코드 가독성을 위한 주석이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->